### PR TITLE
Improve OpenAI config loading

### DIFF
--- a/src/command/message/action.ts
+++ b/src/command/message/action.ts
@@ -27,7 +27,7 @@ export async function messageAction(options: MessageOptions) {
     process.exit(1);
   }
 
-  isGitRepository();
+  await isGitRepository();
 
   try {
     let diff = '';

--- a/src/command/review/action.ts
+++ b/src/command/review/action.ts
@@ -30,12 +30,11 @@ export async function reviewAction(options: ReviewOptions) {
     );
     process.exit(1);
   }
-  console.log(chalk.yellow('Reviewing provided text content...'));
-
   try {
     let diff: string;
 
     if (options.text) {
+      console.log(chalk.yellow('Reviewing provided text content...'));
       diff = options.text;
     } else if (options.file) {
       try {
@@ -46,7 +45,7 @@ export async function reviewAction(options: ReviewOptions) {
         process.exit(1);
       }
     } else {
-      isGitRepository();
+      await isGitRepository();
 
       const contextLines = parseInt(options.unified);
       const baseArgs: string[] = options.args && options.args.length > 0 ? options.args : ['HEAD'];

--- a/src/config/openaiConfig.ts
+++ b/src/config/openaiConfig.ts
@@ -1,12 +1,17 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import dotenv from 'dotenv';
+
+// Load environment variables from .env.local if present
+dotenv.config({ path: path.join(process.cwd(), '.env.local'), override: true });
 
 const configFilePath = path.join(os.homedir(), '.commitgenie_config.json');
 
 export const getOpenAIConfig = () => {
-  let apiKey = '';
-  let model = 'gpt-4o-mini'; // default model
+  // Defaults can come from environment variables
+  let apiKey = process.env.OPENAI_API_KEY || '';
+  let model = process.env.OPENAI_MODEL || 'gpt-4o-mini'; // default model
 
   // if config file exists, read config
   if (fs.existsSync(configFilePath)) {


### PR DESCRIPTION
## Summary
- load env vars from `.env.local` and `process.env` when getting OpenAI config
- await Git repo check in `message` and `review` commands
- show text review message only when appropriate

## Testing
- `bun run build`
- `node bin/index.js --version`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68403cfa7ed8833299233304dc5d8464