### PR TITLE
Add bun test setup with basic unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "bun build --target node ./src/index.ts --outdir ./bin --splitting --minify",
     "release:patch": "npm run build && npm version patch && npm publish && git push --follow-tags",
     "release:minor": "npm run build && npm version minor && npm publish && git push --follow-tags",
-    "release:major": "npm run build && npm version major && npm publish && git push --follow-tags"
+    "release:major": "npm run build && npm version major && npm publish && git push --follow-tags",
+    "test": "bun test"
   },
   "type": "module",
   "bin": {

--- a/tests/openaiConfig.test.ts
+++ b/tests/openaiConfig.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from 'bun:test';
+import { getOpenAIConfig } from '../src/config/openaiConfig';
+
+const originalApiKey = process.env.OPENAI_API_KEY;
+const originalModel = process.env.OPENAI_MODEL;
+
+test('getOpenAIConfig returns values from environment variables', () => {
+  process.env.OPENAI_API_KEY = 'test-key';
+  process.env.OPENAI_MODEL = 'gpt-test';
+  const config = getOpenAIConfig();
+  expect(config.apiKey).toBe('test-key');
+  expect(config.model).toBe('gpt-test');
+});
+
+test('getOpenAIConfig throws when API key is missing', () => {
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_MODEL;
+  expect(() => getOpenAIConfig()).toThrow();
+});
+
+// restore environment
+process.env.OPENAI_API_KEY = originalApiKey;
+process.env.OPENAI_MODEL = originalModel;


### PR DESCRIPTION
## Summary
- add `bun test` script
- implement simple `getOpenAIConfig` unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840441cf2c88332a8cb7d2a55b6c03b