### PR TITLE
Make review chunk size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ CommitGenie is a CLI tool that leverages LLM technology to assist in the softwar
   - Customize the number of context lines for better understanding of changes.
   - Review specific files or entire repositories.
   - Supports reviewing pure text content or content from a file.
+  - Adjustable chunk size for large reviews via the `--chunk-size` option.
 
 - **AI-Assisted Commit Message Generation**: Automatically generates meaningful commit messages based on code changes.
 

--- a/src/command/review/action.ts
+++ b/src/command/review/action.ts
@@ -11,11 +11,24 @@ import { COMMON_IGNORE_FILES } from '../../config';
 
 const git = simpleGit();
 
+const estimateChunkSize = (model: string) => {
+  const lower = model.toLowerCase();
+  let tokenLimit = 16000;
+  if (lower.includes('3.5')) tokenLimit = 4096;
+  else if (lower.includes('32k')) tokenLimit = 32768;
+  else if (lower.includes('128k') || lower.includes('4o')) tokenLimit = 128000;
+
+  const availableTokens = tokenLimit - 1000; // reserve tokens for instructions
+  const charCount = availableTokens * 4; // rough token to char conversion
+  return Math.min(charCount, 16000); // cap to avoid very large chunks
+};
+
 type ReviewOptions = {
   args: string[];
   unified: string;
   text?: string;
   file?: string;
+  chunkSize: string;
 };
 
 export async function reviewAction(options: ReviewOptions) {
@@ -77,8 +90,13 @@ export async function reviewAction(options: ReviewOptions) {
       apiKey
     });
 
+    const chunkSize =
+      options.chunkSize === 'auto'
+        ? estimateChunkSize(model)
+        : parseInt(options.chunkSize, 10);
+
     const textSplitter = new RecursiveCharacterTextSplitter({
-      chunkSize: 16000,
+      chunkSize,
       chunkOverlap: 1000
     });
 

--- a/src/command/review/review.ts
+++ b/src/command/review/review.ts
@@ -8,6 +8,11 @@ export const createReviewCommand = (program: Command) => {
     .option('-U, --unified <n>', 'Generate diffs with <n> lines of context', '10')
     .option('-t, --text <text>', 'Provide pure text content for review')
     .option('-f, --file <path>', 'Provide a file path containing the content for review')
+    .option(
+      '-c, --chunk-size <n|auto>',
+      'Chunk size for text splitting (use "auto" to estimate based on the model)',
+      '4000'
+    )
     .allowUnknownOption(true)
     .action((args, options) => reviewAction({ ...options, args }))
     .addHelpText(
@@ -54,6 +59,7 @@ Notes:
   - Use -- to separate paths from other options, especially when reviewing specific files.
   - Use -t or --text to provide pure text content for review.
   - Use -f or --file to provide a file path containing the content for review.
+  - Use -c or --chunk-size to control how large each diff chunk is when sent to the AI.
     `
     );
 };


### PR DESCRIPTION
## Summary
- expose `--chunk-size` option for the review command
- add helper to estimate chunk size from the model
- default to 4k character chunks
- document `--chunk-size` in README

## Testing
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_68404883677483329c7cded62a1d063d